### PR TITLE
Testcase for escaping seval encapsulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # seval
 
-`seval` provides a meta-circular Python interpretter for user interaction. It is
+`seval` provides a meta-circular Python interpreter for user interaction. It is
 designed to safely evaluate python code without allowing calls to access the
 underlying operating system.
 
 This is done by evaluation of python expressions under a restricted environment.
-Various python libaries are forbidden, and access to private fields is
-prohibitted.
+Various python libraries are forbidden, and access to private fields is
+prohibited.
 
 ```
 >>> "".__repr__()
@@ -31,15 +31,19 @@ implementation installed from pip. `anyreadline` is a metapackage which installs
 a readline library appropriate for your operating system. The `gnureadline`
 package is incompatible with Windows.
 
-## Build
+## Build, test, install
 
-Building is simple using setuptools
+### Build
+Building is simple using setuptools. It is advisable to work in a virtualenv.
 
 ```shellsession
+$ virtualenv .
+$ . bin/activate
+# Install dependencies using pip
 $ python3 ./setup.py build
 ```
 
-## Test
+### Test
 
 Tests are in the `test/` directory. They're using the `unittest`
 library and don't currently cover much of seval.
@@ -47,3 +51,19 @@ library and don't currently cover much of seval.
 ```shellsession
 $ python3 ./setup.py test
 ```
+
+### Install
+
+Installation is also done with setuptools.
+
+```shellsession
+$ python3 ./setup.py test
+```
+
+This will put the following into a `bin/` directory
+
+ - basic_repl.py
+ - pt_repl.py
+ - readline_repl.py
+ 
+

--- a/README.md
+++ b/README.md
@@ -31,3 +31,19 @@ implementation installed from pip. `anyreadline` is a metapackage which installs
 a readline library appropriate for your operating system. The `gnureadline`
 package is incompatible with Windows.
 
+## Build
+
+Building is simple using setuptools
+
+```shellsession
+$ python3 ./setup.py build
+```
+
+## Test
+
+Tests are in the `test/` directory. They're using the `unittest`
+library and don't currently cover much of seval.
+
+```shellsession
+$ python3 ./setup.py test
+```

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,6 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation',
-
-
     ],
 
     # What does your project relate to?
@@ -48,4 +46,19 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['docs', 'tests']),
+
+    scripts=[
+        "./seval/repls/basic_repl.py",
+        "./seval/repls/pt_repl.py",
+        "./seval/repls/readline_repl.py",        
+    ],
+    
+    setup_requires=[
+        'pytest-runner',
+    ],
+
+    test_require=[
+        'pytest',
+        'seval',
+    ],
 )

--- a/seval/repls/basic_repl.py
+++ b/seval/repls/basic_repl.py
@@ -1,8 +1,8 @@
 from seval.seval import parse_string
-from seval.globalenv import globalenv
+from seval import global_env
 
 def main():
-    env = globalenv
+    env = global_env.globalenv
 
     while True:
         x = input("> ")

--- a/seval/repls/readline_repl.py
+++ b/seval/repls/readline_repl.py
@@ -3,9 +3,10 @@ import atexit
 import os
 import sys
 
-import global_env
 import readline
 
+import seval
+from seval import global_env
 from seval.seval import parse_string
 from seval.repls import readline_completer
 

--- a/tests/test_encapsulation.py
+++ b/tests/test_encapsulation.py
@@ -1,0 +1,15 @@
+import unittest
+
+import seval
+import seval.global_env
+
+# Used to get to sys in test_no_sysver
+import json
+
+class EncapsulationTest(unittest.TestCase):
+    def test_no_sysver(self):
+        print(repr(seval.global_env))
+        env = seval.global_env.globalenv
+        env['json'] = json
+        with self.assertRaises(Exception) as _:
+            seval.seval.parse_string(env, "json.codecs.sys.version")


### PR DESCRIPTION
This is a test case for #1 and some infrastructure to make testing easier. Should work nicely with pycharm and works on the command line with

```shellsession
python3 ./setup.py test
```

I've also added the repls to an install script. 